### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/deploy-docker-custom-message.yml
+++ b/.github/workflows/deploy-docker-custom-message.yml
@@ -15,7 +15,7 @@ jobs:
           profile:              minimal
           override:             true
       - name:                   Deploy to docker hub
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: openethereum/openethereum
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -21,7 +21,7 @@ jobs:
           profile:              minimal
           override:             true
       - name:                   Deploy to docker hub
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: openethereum/openethereum
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore